### PR TITLE
Fix incorrect cmp_ok() test; replace with is().

### DIFF
--- a/t/06-render-default.t
+++ b/t/06-render-default.t
@@ -25,12 +25,12 @@ my $expected=<<EOT;
 <div>
 <label for="gcaptcha">Gcaptcha</label>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-<div class="g-recaptcha" data-sitekey="fake site key" data-theme="dark"></div>
+<div class="g-recaptcha" data-sitekey="fake site key" data-theme="light"></div>
 
 </div>
 </form>
 EOT
 
-cmp_ok($expected,'cmp',$form->render,'to make sure no unexpected output changes are made');
+is($form->render,$expected,'make sure no unexpected output changes are made');
 
 done_testing();


### PR DESCRIPTION
The use of cmp_ok($foo,'cmp',$bar) doesn't match correctly. In particular, the cmp operator will return 0 (false) when they match, and -1 or 1 (true) when they are not matched - that's the opposite of what we want.

This replaces that test with a simple is() test, and fixes the incorrect markup.

See also: https://github.com/clarson/Captcha-noCAPTCHA/pull/3
